### PR TITLE
Return correct error: coordinatorConnection

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -329,7 +329,7 @@ func (b *Broker) coordinatorConnection(consumerGroup string) (conn *connection, 
 			}
 			if resp.Err != nil {
 				b.mu.Unlock()
-				return nil, err
+				return nil, resp.Err
 			}
 
 			addr := fmt.Sprintf("%s:%d", resp.CoordinatorHost, resp.CoordinatorPort)
@@ -370,7 +370,7 @@ func (b *Broker) coordinatorConnection(consumerGroup string) (conn *connection, 
 			}
 			if resp.Err != nil {
 				b.mu.Unlock()
-				return nil, err
+				return nil, resp.Err
 			}
 
 			addr := fmt.Sprintf("%s:%d", resp.CoordinatorHost, resp.CoordinatorPort)


### PR DESCRIPTION
This was causing a panic when a user group did not exist. The connection
loop checks for a non-nil `resp.Err`, and if found then returns the
local variable `err` which is nil.

Later on this nil value is used to verify that the connection is non-nil
and therefore causes panic when the connection is expanded.