### PR TITLE
Add ability to specify partitioner

### DIFF
--- a/broker_test.go
+++ b/broker_test.go
@@ -77,7 +77,9 @@ func TestProducer(t *testing.T) {
 		&proto.Message{Value: []byte("first")},
 		&proto.Message{Value: []byte("second")},
 	}
-	_, err = producer.Produce("does-not-exist", 42142, messages...)
+	_, err = producer.Produce("does-not-exist",
+		func(string, ...*proto.Message) int { return 42142 },
+		messages...)
 	if err != proto.ErrUnknownTopicOrPartition {
 		t.Fatalf("expected '%s', got %s", proto.ErrUnknownTopicOrPartition, err)
 	}
@@ -119,7 +121,7 @@ func TestProducer(t *testing.T) {
 		}
 	})
 
-	offset, err := producer.Produce("test", 0, messages...)
+	offset, err := producer.Produce("test", broker.RandomPartition, messages...)
 	if handleErr != nil {
 		t.Fatalf("handling error: %s", handleErr)
 	}


### PR DESCRIPTION
Many writers won't care what partition their data goes to, they just
want it done randomly. Since we're using signed numbers here, we can use
negative numbers to indicate to use some special partitioning logic.