### PR TITLE
Auto partition

### DIFF
--- a/distributed_producer_test.go
+++ b/distributed_producer_test.go
@@ -1,0 +1,82 @@
+package kafka
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/optiopay/kafka/proto"
+)
+
+type recordingProducer struct {
+	sync.Mutex
+	msgs []*proto.Message
+}
+
+func newRecordingProducer() *recordingProducer {
+	return &recordingProducer{msgs: make([]*proto.Message, 0)}
+}
+
+func (p *recordingProducer) Produce(topic string, part int32, msgs ...*proto.Message) (int64, error) {
+	p.Lock()
+	defer p.Unlock()
+
+	offset := len(p.msgs)
+	p.msgs = append(p.msgs, msgs...)
+	for i, msg := range msgs {
+		msg.Offset = int64(offset + i)
+		msg.Topic = topic
+		msg.Partition = part
+	}
+	return int64(len(p.msgs)), nil
+}
+
+func TestRoundRobinProducer(t *testing.T) {
+	rec := newRecordingProducer()
+	p := NewRoundRobinProducer(rec, 3)
+
+	data := [][][]byte{
+		[][]byte{
+			[]byte("a 1"),
+			[]byte("a 2"),
+		},
+		[][]byte{
+			[]byte("b 1"),
+		},
+		[][]byte{
+			[]byte("c 1"),
+			[]byte("c 2"),
+			[]byte("c 3"),
+		},
+		[][]byte{
+			[]byte("d 1"),
+		},
+	}
+
+	for _, values := range data {
+		msgs := make([]*proto.Message, 0)
+		for _, value := range values {
+			msgs = append(msgs, &proto.Message{Value: value})
+		}
+		p.Distribute("test-topic", msgs...)
+	}
+
+	// a, [0, 1]
+	if rec.msgs[0].Partition != 0 || rec.msgs[1].Partition != 0 {
+		t.Fatalf("expected partition 0, got %d and %d", rec.msgs[0].Partition, rec.msgs[1].Partition)
+	}
+
+	// b, [2]
+	if rec.msgs[2].Partition != 1 {
+		t.Fatalf("expected partition 1, got %d", rec.msgs[2].Partition)
+	}
+
+	// c, [3, 4, 5]
+	if rec.msgs[3].Partition != 2 || rec.msgs[4].Partition != 2 {
+		t.Fatalf("expected partition 2, got %d and %d", rec.msgs[3].Partition, rec.msgs[3].Partition)
+	}
+
+	// d, [6]
+	if rec.msgs[6].Partition != 0 {
+		t.Fatalf("expected partition 0, got %d", rec.msgs[6].Partition)
+	}
+}

--- a/partitioners.go
+++ b/partitioners.go
@@ -1,0 +1,140 @@
+package kafka
+
+import (
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/optiopay/kafka/proto"
+)
+
+// PartitionedProducer is the interface similar to Producer, but never require
+// to explicitly specify partition.
+//
+// Produce writes messages to the given topic, automatically choosing
+// partition, returning the post-commit offset and any error encountered. The
+// offset of each message is also updated accordingly.
+type PartitionedProducer interface {
+	Produce(topic string, messages ...*proto.Message) (offset int64, err error)
+}
+
+type randomProducer struct {
+	rand       *rand.Rand
+	producer   Producer
+	partitions int32
+}
+
+// NewRandomProducer wraps given producer and return PartitionedProducer that
+// publish messages to kafka, randomly picking partition number from range
+// [0, numPartitions)
+func NewRandomPartProducer(p Producer, numPartitions int32) PartitionedProducer {
+	return &randomProducer{
+		rand:       rand.New(rand.NewSource(time.Now().UnixNano())),
+		producer:   p,
+		partitions: numPartitions,
+	}
+}
+
+// Produce write messages to given kafka topic, randomly destination choosing
+// partition. All messages written within single Produce call are atomically
+// written to the same destination.
+func (p *randomProducer) Produce(topic string, messages ...*proto.Message) (offset int64, err error) {
+	part := p.rand.Intn(int(p.partitions))
+	return p.producer.Produce(topic, int32(part), messages...)
+}
+
+type roundRobinProducer struct {
+	producer   Producer
+	partitions int32
+	mu         sync.Mutex
+	next       int32
+}
+
+// NewRoundRobinProducer wraps given producer and return PartitionedProducer
+// that publish messages to kafka, choosing destination partition from cycle
+// build from [0, numPartitions) range.
+func NewRoundRobinProducer(p Producer, numPartitions int32) PartitionedProducer {
+	return &roundRobinProducer{
+		producer:   p,
+		partitions: numPartitions,
+		next:       0,
+	}
+}
+
+// Produce write messages to given kafka topic, choosing next destination
+// partition from internal cycle. All messages written within single Produce
+// call are atomically written to the same destination.
+func (p *roundRobinProducer) Produce(topic string, messages ...*proto.Message) (offset int64, err error) {
+	p.mu.Lock()
+	part := p.next
+	p.next++
+	if p.next >= p.partitions {
+		p.next = 0
+	}
+	p.mu.Unlock()
+
+	return p.producer.Produce(topic, int32(part), messages...)
+}
+
+type hashProducer struct {
+	producer   Producer
+	partitions int32
+}
+
+// NewHashProducer wraps given producer and return PartitionedProducer that
+// publish messages to kafka, computing partition number from message key hash,
+// using fnv hash and [0, numPartitions) range.
+func NewHashProducer(p Producer, numPartitions int32) PartitionedProducer {
+	return &hashProducer{
+		producer:   p,
+		partitions: numPartitions,
+	}
+}
+
+// Produce write messages to given kafka topic, computing partition number from
+// the message key value. Message key must be not nil and all messages written
+// within single Produce call are atomically written to the same destination.
+//
+// All messages passed within single Produce call must hash to the same
+// destination, otherwise no message is written and error is returned.
+func (p *hashProducer) Produce(topic string, messages ...*proto.Message) (offset int64, err error) {
+	if len(messages) == 0 {
+		return 0, errors.New("no messages")
+	}
+	part, err := p.messagePartition(messages[0])
+	if err != nil {
+		return 0, fmt.Errorf("cannot hash message: %s", err)
+	}
+	// make sure that all messages within single call are to the same destination
+	for i := 2; i < len(messages); i++ {
+		mp, err := p.messagePartition(messages[i])
+		if err != nil {
+			return 0, fmt.Errorf("cannot hash message: %s", err)
+		}
+		if part != mp {
+			return 0, errors.New("cannot publish messages to different destinations")
+		}
+	}
+
+	return p.producer.Produce(topic, part, messages...)
+}
+
+// messagePartition compute message's key hash and return corresponding
+// partition number.
+func (p *hashProducer) messagePartition(m *proto.Message) (int32, error) {
+	if m.Key == nil {
+		return 0, errors.New("no key")
+	}
+	hasher := fnv.New32a()
+	if _, err := hasher.Write(m.Key); err != nil {
+		return 0, fmt.Errorf("cannot hash key: %s", err)
+	}
+	sum := int32(hasher.Sum32())
+	if sum < 0 {
+		sum = -sum
+	}
+	return sum / p.partitions, nil
+}


### PR DESCRIPTION
To allow publishing messages without explicit partition number passing, new interface was created with tree initial implementations providing random, hashed and round robin partitioners for producing messages.

closing #10 