### PR TITLE
connection error handling updated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,12 @@ before_install:
 - go get github.com/kisielk/errcheck
 
 script:
-- go test -v -race -timeout=60s github.com/optiopay/kafka/...
+- go test -v -race -timeout=90s github.com/optiopay/kafka/...
 - go vet github.com/optiopay/kafka/...
 - errcheck github.com/optiopay/kafka/...
+
+env:
+- WITH_INTEGRATION=true
+- GOMAXPROCS=4
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,13 @@ before_install:
 - go get golang.org/x/tools/cmd/vet
 - go get github.com/kisielk/errcheck
 
+
 script:
 - go test -v -race -timeout=90s github.com/optiopay/kafka/...
 - go vet github.com/optiopay/kafka/...
 - errcheck github.com/optiopay/kafka/...
 
 env:
-- WITH_INTEGRATION=true
-- GOMAXPROCS=4
+- WITH_INTEGRATION=true GOMAXPROCS=4
 
 sudo: false

--- a/connection_test.go
+++ b/connection_test.go
@@ -509,7 +509,9 @@ func TestConnectionReaderAfterEOF(t *testing.T) {
 	if err != nil {
 		t.Fatalf("test server error: %s", err)
 	}
-	defer ln.Close()
+	defer func() {
+		_ = ln.Close()
+	}()
 
 	conn, err := newTCPConnection(ln.Addr().String(), time.Second)
 	if err != nil {

--- a/connection_test.go
+++ b/connection_test.go
@@ -430,6 +430,8 @@ func TestClosedConnectionWriter(t *testing.T) {
 
 	// although we produced ten requests, because connection is closed, no
 	// response channel should be registered
+	conn.mu.Lock()
+	defer conn.mu.Unlock()
 	if len(conn.respc) != 0 {
 		t.Fatalf("expected 0 waiting responses, got %d", len(conn.respc))
 	}
@@ -473,6 +475,8 @@ func TestClosedConnectionReader(t *testing.T) {
 
 	// although we produced ten requests, because connection is closed, no
 	// response channel should be registered
+	conn.mu.Lock()
+	defer conn.mu.Unlock()
 	if len(conn.respc) != 0 {
 		t.Fatalf("expected 0 waiting responses, got %d", len(conn.respc))
 	}

--- a/connection_test.go
+++ b/connection_test.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"net"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -41,6 +42,7 @@ func testServer(messages ...serializableMessage) (net.Listener, error) {
 				for _, resp := range responses {
 					_, _ = cli.Write(resp)
 				}
+				cli.Close()
 			}(cli)
 		}
 	}()
@@ -386,5 +388,92 @@ func TestConnectionProduceNoAck(t *testing.T) {
 	}
 	if err := ln.Close(); err != nil {
 		t.Fatalf("could not close test server: %s", err)
+	}
+}
+
+func TestClosedConnectionWriter(t *testing.T) {
+	// create test server with no messages, so that any client connection will
+	// be immediately closed
+	ln, err := testServer()
+	if err != nil {
+		t.Fatalf("test server error: %s", err)
+	}
+	conn, err := newTCPConnection(ln.Addr().String(), time.Second)
+	if err != nil {
+		t.Fatalf("could not conect to test server: %s", err)
+	}
+
+	longBytes := []byte(strings.Repeat("xxxxxxxxxxxxxxxxxxxxxx", 1000))
+	req := proto.ProduceReq{
+		ClientID:     "test-client",
+		RequiredAcks: proto.RequiredAcksAll,
+		Timeout:      100,
+		Topics: []proto.ProduceReqTopic{
+			proto.ProduceReqTopic{
+				Name: "test-topic",
+				Partitions: []proto.ProduceReqPartition{
+					proto.ProduceReqPartition{
+						ID: 0,
+						Messages: []*proto.Message{
+							&proto.Message{Value: longBytes},
+						},
+					},
+				},
+			},
+		},
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := conn.Produce(&req); err == nil {
+			t.Fatal("message publishing after closing connection should not be possible")
+		}
+	}
+
+	// although we produced ten requests, because connection is closed, no
+	// response channel should be registered
+	if len(conn.respc) != 0 {
+		t.Fatalf("expected 0 waiting responses, got %d", len(conn.respc))
+	}
+}
+
+func TestClosedConnectionReader(t *testing.T) {
+	// create test server with no messages, so that any client connection will
+	// be immediately closed
+	ln, err := testServer()
+	if err != nil {
+		t.Fatalf("test server error: %s", err)
+	}
+	conn, err := newTCPConnection(ln.Addr().String(), time.Second)
+	if err != nil {
+		t.Fatalf("could not conect to test server: %s", err)
+	}
+
+	req := &proto.FetchReq{
+		ClientID:    "test-client",
+		MaxWaitTime: 100,
+		MinBytes:    0,
+		Topics: []proto.FetchReqTopic{
+			proto.FetchReqTopic{
+				Name: "my-topic",
+				Partitions: []proto.FetchReqPartition{
+					proto.FetchReqPartition{
+						ID:          0,
+						FetchOffset: 1,
+						MaxBytes:    100000,
+					},
+				},
+			},
+		},
+	}
+
+	for i := 0; i < 10; i++ {
+		if _, err := conn.Fetch(req); err == nil {
+			t.Fatal("fetching from closed connection succeeded")
+		}
+	}
+
+	// although we produced ten requests, because connection is closed, no
+	// response channel should be registered
+	if len(conn.respc) != 0 {
+		t.Fatalf("expected 0 waiting responses, got %d", len(conn.respc))
 	}
 }

--- a/connection_test.go
+++ b/connection_test.go
@@ -42,7 +42,7 @@ func testServer(messages ...serializableMessage) (net.Listener, error) {
 				for _, resp := range responses {
 					_, _ = cli.Write(resp)
 				}
-				cli.Close()
+				_ = cli.Close()
 			}(cli)
 		}
 	}()

--- a/connection_test.go
+++ b/connection_test.go
@@ -82,6 +82,28 @@ func testServer2() (net.Listener, chan serializableMessage, error) {
 	return ln, msgs, nil
 }
 
+func testServer3() (net.Listener, error) {
+	ln, err := net.Listen("tcp", "")
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		for {
+			cli, err := ln.Accept()
+			if err != nil {
+				return
+			}
+
+			go func(conn net.Conn) {
+				_, _ = cli.Read(make([]byte, 1024))
+				_ = cli.Close()
+			}(cli)
+		}
+	}()
+	return ln, nil
+}
+
 func TestConnectionMetadata(t *testing.T) {
 	resp1 := &proto.MetadataResp{
 		CorrelationID: 1,
@@ -479,5 +501,47 @@ func TestClosedConnectionReader(t *testing.T) {
 	defer conn.mu.Unlock()
 	if len(conn.respc) != 0 {
 		t.Fatalf("expected 0 waiting responses, got %d", len(conn.respc))
+	}
+}
+
+func TestConnectionReaderAfterEOF(t *testing.T) {
+	ln, err := testServer3()
+	if err != nil {
+		t.Fatalf("test server error: %s", err)
+	}
+	defer ln.Close()
+
+	conn, err := newTCPConnection(ln.Addr().String(), time.Second)
+	if err != nil {
+		t.Fatalf("could not conect to test server: %s", err)
+	}
+
+	req := &proto.FetchReq{
+		ClientID:    "test-client",
+		MaxWaitTime: 100,
+		MinBytes:    0,
+		Topics: []proto.FetchReqTopic{
+			proto.FetchReqTopic{
+				Name: "my-topic",
+				Partitions: []proto.FetchReqPartition{
+					proto.FetchReqPartition{
+						ID:          0,
+						FetchOffset: 1,
+						MaxBytes:    100000,
+					},
+				},
+			},
+		},
+	}
+
+	if _, err := conn.Fetch(req); err == nil {
+		t.Fatal("fetching from closed connection succeeded")
+	}
+
+	// Wait until testServer3 closes connection
+	time.Sleep(time.Millisecond * 50)
+
+	if _, err := conn.Fetch(req); err == nil {
+		t.Fatal("fetching from closed connection succeeded")
 	}
 }

--- a/integration/README.md
+++ b/integration/README.md
@@ -1,0 +1,14 @@
+# integration
+
+Integration with kafka & zoopeeker test helpers.
+
+`KafkaCluster` depends on `docker` and `docker-compose` commands.
+
+**IMPORTANT**: Make sure to update `KAFKA_ADVERTISED_HOST_NAME` in
+`kafka-docker/docker-compose.yml` before running tests.
+
+## kafka-docker
+
+[kafka-docker](/integration/kafka-docker) directory is copy of
+[wurstmeister/kafka-docker](https://github.com/wurstmeister/kafka-docker)
+repository.

--- a/integration/broker_test.go
+++ b/integration/broker_test.go
@@ -1,0 +1,118 @@
+package integration
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/optiopay/kafka"
+	"github.com/optiopay/kafka/proto"
+)
+
+func TestProducerBrokenConnection(t *testing.T) {
+	IntegrationTest(t)
+
+	topics := []string{"Topic1", "Topic2", "Topic3"}
+
+	cluster := NewKafkaCluster("kafka-docker/", 4)
+	if err := cluster.Start(); err != nil {
+		t.Fatalf("cannot start kafka cluster: %s", err)
+	}
+	defer cluster.Stop()
+
+	bconf := kafka.NewBrokerConf("producer-broken-connection")
+	bconf.Log = &testLogger{t}
+	addrs, err := cluster.KafkaAddrs()
+	if err != nil {
+		t.Fatalf("cannot get kafka address: %s", err)
+	}
+	broker, err := kafka.Dial(addrs, bconf)
+	if err != nil {
+		t.Fatalf("cannot connect to cluster (%q): %s", addrs, err)
+	}
+	defer broker.Close()
+
+	// produce big message to enforce TCP buffer flush
+	m := proto.Message{
+		Value: []byte(strings.Repeat("producer broken connection message ", 1000)),
+	}
+	pconf := kafka.NewProducerConf()
+	producer := broker.Producer(pconf)
+
+	// send message to all topics to make sure it's working
+	for _, name := range topics {
+		if _, err := producer.Produce(name, 0, &m); err != nil {
+			t.Fatalf("cannot produce to %q: %s", name, err)
+		}
+	}
+
+	// close two kafka clusters and publish to all 3 topics - 2 of them should
+	// retry sending, because lack of leader makes the request fail
+	//
+	// request should not succeed until nodes are back - bring them back after
+	// small delay and make sure producing was successful
+	containers, err := cluster.Containers()
+	if err != nil {
+		t.Fatalf("cannot get containers: %s", err)
+	}
+	var stopped []*Container
+	for _, container := range containers {
+		if container.RunningKafka() {
+			if err := container.Stop(); err != nil {
+				t.Fatalf("cannot stop %q kafka container: %s", container.ID, err)
+			}
+			stopped = append(stopped, container)
+		}
+		if len(stopped) == 2 {
+			break
+		}
+	}
+
+	// bring stopped containers back
+	errc := make(chan error)
+	go func() {
+		time.Sleep(1200 * time.Millisecond)
+		for _, container := range stopped {
+			if err := container.Start(); err != nil {
+				errc <- err
+			}
+		}
+		close(errc)
+	}()
+
+	// send message to all topics to make sure it's working
+	for _, name := range topics {
+		if _, err := producer.Produce(name, 0, &m); err != nil {
+			t.Fatalf("cannot produce to %q: %s", name, err)
+		}
+	}
+
+	for err := range errc {
+		t.Fatalf("cannot start container: %s", err)
+	}
+
+	// make sure data was persisted
+	for _, name := range topics {
+		consumer, err := broker.Consumer(kafka.NewConsumerConf(name, 0))
+		if err != nil {
+			t.Fatalf("cannot create consumer for %q: %s", name, err)
+		}
+		for i := 0; i < 2; i++ {
+			if _, err := consumer.Consume(); err != nil {
+				t.Fatalf("cannot consume %d message from %q: %s", i, name, err)
+			}
+		}
+	}
+}
+
+type testLogger struct {
+	*testing.T
+}
+
+func (tlog *testLogger) Print(args ...interface{}) {
+	tlog.Log(args...)
+}
+
+func (tlog *testLogger) Printf(format string, args ...interface{}) {
+	tlog.Logf(format, args...)
+}

--- a/integration/broker_test.go
+++ b/integration/broker_test.go
@@ -18,7 +18,9 @@ func TestProducerBrokenConnection(t *testing.T) {
 	if err := cluster.Start(); err != nil {
 		t.Fatalf("cannot start kafka cluster: %s", err)
 	}
-	defer cluster.Stop()
+	defer func() {
+		_ = cluster.Stop()
+	}()
 
 	bconf := kafka.NewBrokerConf("producer-broken-connection")
 	bconf.Log = &testLogger{t}

--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -1,0 +1,208 @@
+package integration
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+type KafkaCluster struct {
+	// cluster size == number of kafka nodes
+	size           int
+	kafkaDockerDir string
+	verbose        bool
+
+	mu         sync.Mutex
+	containers []*Container
+}
+
+type Container struct {
+	cluster *KafkaCluster
+
+	ID     string `json:"Id"`
+	Image  string
+	Args   []string
+	Config struct {
+		Cmd          []string
+		Env          []string
+		ExposedPorts map[string]interface{}
+	}
+	NetworkSettings struct {
+		Gateway   string
+		IPAddress string
+		Ports     map[string][]PortMapping
+	}
+}
+
+type PortMapping struct {
+	HostIP   string `json:"HostIp"`
+	HostPort string
+}
+
+func NewKafkaCluster(kafkaDockerDir string, size int) *KafkaCluster {
+	return &KafkaCluster{
+		kafkaDockerDir: kafkaDockerDir,
+		size:           size,
+	}
+}
+
+// RunningKafka returns true if container is running kafka node
+func (c *Container) RunningKafka() bool {
+	return c.Args[1] == "start-kafka.sh"
+}
+
+// Start starts current container
+func (c *Container) Start() error {
+	return c.cluster.ContainerStart(c.ID)
+}
+
+// Stop stops current container
+func (c *Container) Stop() error {
+	return c.cluster.ContainerStop(c.ID)
+}
+
+// Start start zookeeper and kafka nodes using docker-compose command. Upon
+// successful process spawn, cluster is scaled to required amount of nodes.
+func (cluster *KafkaCluster) Start() error {
+	cluster.mu.Lock()
+	defer cluster.mu.Unlock()
+
+	// ensure  cluster is not running
+	if err := cluster.Stop(); err != nil {
+		return fmt.Errorf("cannot ensure stop cluster: %s", err)
+	}
+	if err := cluster.removeStoppedContainers(); err != nil {
+		return fmt.Errorf("cannot cleanup dead containers: %s", err)
+	}
+
+	upCmd := cluster.cmd("docker-compose", "up", "-d")
+	if err := upCmd.Run(); err != nil {
+		return fmt.Errorf("docker-compose error: %s", err)
+	}
+
+	scaleCmd := cluster.cmd("docker-compose", "scale", fmt.Sprintf("kafka=%d", cluster.size))
+	if err := scaleCmd.Run(); err != nil {
+		_ = cluster.Stop()
+		return fmt.Errorf("cannot scale kafka: %s", err)
+	}
+
+	containers, err := cluster.Containers()
+	if err != nil {
+		_ = cluster.Stop()
+		return fmt.Errorf("cannot get containers info: %s", err)
+	}
+	cluster.containers = containers
+	return nil
+}
+
+// Containers inspect all containers running within cluster and return
+// information about them.
+func (cluster *KafkaCluster) Containers() ([]*Container, error) {
+	psCmd := cluster.cmd("docker-compose", "ps", "-q")
+	var buf bytes.Buffer
+	psCmd.Stdout = &buf
+	if err := psCmd.Run(); err != nil {
+		return nil, fmt.Errorf("cannot list processes: %s", err)
+	}
+
+	rd := bufio.NewReader(&buf)
+	inspectArgs := []string{"inspect"}
+	for {
+		line, err := rd.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("cannot read \"ps\" output: %s", err)
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		inspectArgs = append(inspectArgs, line)
+	}
+
+	inspectCmd := cluster.cmd("docker", inspectArgs...)
+	buf.Reset()
+	inspectCmd.Stdout = &buf
+	if err := inspectCmd.Run(); err != nil {
+		return nil, fmt.Errorf("inspect failed: %s", err)
+	}
+	var containers []*Container
+	if err := json.NewDecoder(&buf).Decode(&containers); err != nil {
+		return nil, fmt.Errorf("cannot decode inspection: %s", err)
+	}
+	for _, c := range containers {
+		c.cluster = cluster
+	}
+	return containers, nil
+}
+
+// Stop stop all services running for the cluster by sending SIGINT to
+// docker-compose process.
+func (cluster *KafkaCluster) Stop() error {
+	cmd := cluster.cmd("docker-compose", "stop", "-t", "0")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("docker-compose stop failed: %s", err)
+	}
+	_ = cluster.removeStoppedContainers()
+	return nil
+}
+
+// KafkaAddrs return list of kafka node addresses as strings, in form
+// <host>:<port>
+func (cluster *KafkaCluster) KafkaAddrs() ([]string, error) {
+	containers, err := cluster.Containers()
+	if err != nil {
+		return nil, fmt.Errorf("cannot get containers info: %s", err)
+	}
+	addrs := make([]string, 0)
+	for _, container := range containers {
+		ports, ok := container.NetworkSettings.Ports["9092/tcp"]
+		if !ok || len(ports) == 0 {
+			continue
+		}
+		addrs = append(addrs, fmt.Sprintf("%s:%s", ports[0].HostIP, ports[0].HostPort))
+	}
+	return addrs, nil
+}
+
+func (cluster *KafkaCluster) ContainerStop(containerID string) error {
+	stopCmd := cluster.cmd("docker", "stop", containerID)
+	if err := stopCmd.Run(); err != nil {
+		return fmt.Errorf("cannot stop %q container: %s", containerID, err)
+	}
+	return nil
+}
+
+func (cluster *KafkaCluster) ContainerStart(containerID string) error {
+	startCmd := cluster.cmd("docker", "start", containerID)
+	if err := startCmd.Run(); err != nil {
+		return fmt.Errorf("cannot start %q container: %s", containerID, err)
+	}
+	return nil
+}
+
+func (cluster *KafkaCluster) cmd(name string, args ...string) *exec.Cmd {
+	c := exec.Command(name, args...)
+	if cluster.verbose {
+		c.Stderr = os.Stderr
+		c.Stdout = os.Stdout
+	}
+	c.Dir = cluster.kafkaDockerDir
+	return c
+}
+
+func (cluster *KafkaCluster) removeStoppedContainers() error {
+	rmCmd := cluster.cmd("docker-compose", "rm", "-f")
+	if err := rmCmd.Run(); err != nil {
+		return fmt.Errorf("docker-compose rm error: %s", err)
+	}
+	return nil
+}

--- a/integration/cluster_test.go
+++ b/integration/cluster_test.go
@@ -6,9 +6,11 @@ import (
 	"testing"
 )
 
+// Integration test skip test if WITH_INTEGRATION environment variable was not
+// set to true.
 func IntegrationTest(t *testing.T) {
-	if ok, _ := strconv.ParseBool(os.Getenv("WITH_INTEGRATION")); ok {
-		t.Skip("integration test")
+	if ok, _ := strconv.ParseBool(os.Getenv("WITH_INTEGRATION")); !ok {
+		t.Skip("Integration test. Set WITH_INTEGRATION=true to run.")
 	}
 }
 

--- a/integration/cluster_test.go
+++ b/integration/cluster_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"os"
+	"os/exec"
 	"strconv"
 	"testing"
 )
@@ -9,9 +10,23 @@ import (
 // Integration test skip test if WITH_INTEGRATION environment variable was not
 // set to true.
 func IntegrationTest(t *testing.T) {
+	if !hasDocker() {
+		t.Skip("Integration test. docker and/or docker-compose tools not available")
+	}
+
 	if ok, _ := strconv.ParseBool(os.Getenv("WITH_INTEGRATION")); !ok {
 		t.Skip("Integration test. Set WITH_INTEGRATION=true to run.")
 	}
+}
+
+func hasDocker() bool {
+	if err := exec.Command("docker", "--version").Run(); err != nil {
+		return false
+	}
+	if err := exec.Command("docker-compose", "--version").Run(); err != nil {
+		return false
+	}
+	return true
 }
 
 func TestKafkaCluster(t *testing.T) {

--- a/integration/cluster_test.go
+++ b/integration/cluster_test.go
@@ -1,0 +1,95 @@
+package integration
+
+import (
+	"os"
+	"strconv"
+	"testing"
+)
+
+func IntegrationTest(t *testing.T) {
+	if ok, _ := strconv.ParseBool(os.Getenv("WITH_INTEGRATION")); ok {
+		t.Skip("integration test")
+	}
+}
+
+func TestKafkaCluster(t *testing.T) {
+	IntegrationTest(t)
+
+	const clusterSize = 3
+
+	cluster := NewKafkaCluster("kafka-docker/", clusterSize)
+	if err := cluster.Start(); err != nil {
+		t.Fatalf("cannot start kafka cluster: %s", err)
+	}
+
+	addrs, err := cluster.KafkaAddrs()
+	if err != nil {
+		t.Fatalf("cannot get kafka cluster addresses: %s", err)
+	}
+	if len(addrs) != clusterSize {
+		t.Fatalf("expected %d addresses, got %d (%v)", clusterSize, len(addrs), addrs)
+	}
+
+	if err := cluster.Stop(); err != nil {
+		t.Fatalf("cannot stop kafka cluster: %s", err)
+	}
+}
+
+func TestContainerRestart(t *testing.T) {
+	IntegrationTest(t)
+
+	cluster := NewKafkaCluster("kafka-docker/", 2)
+	if err := cluster.Start(); err != nil {
+		t.Fatalf("cannot start kafka cluster: %s", err)
+	}
+
+	containers, err := cluster.Containers()
+	if err != nil {
+		t.Fatalf("cannot get containers info: %s", err)
+	}
+	if len(containers) != 3 {
+		t.Fatalf("expected 3 containers, got %d", len(containers))
+	}
+
+	// first stop all zookeeper containers
+	for _, container := range containers {
+		if container.RunningKafka() {
+			continue
+		}
+		if err := container.Stop(); err != nil {
+			t.Fatalf("cannot stop %q container: %s", container.ID, err)
+		}
+	}
+	// then stop all kafka containers
+	for _, container := range containers {
+		if !container.RunningKafka() {
+			continue
+		}
+		if err := container.Stop(); err != nil {
+			t.Fatalf("cannot stop %q container: %s", container.ID, err)
+		}
+	}
+
+	// first start all zookeeper containers
+	for _, container := range containers[1:] {
+		if container.RunningKafka() {
+			continue
+		}
+		if err := container.Start(); err != nil {
+			t.Fatalf("cannot start %q container: %s", container.ID, err)
+		}
+	}
+	// then start all kafka containers
+	for _, container := range containers[1:] {
+		if !container.RunningKafka() {
+			continue
+		}
+		if err := container.Start(); err != nil {
+			t.Fatalf("cannot start %q container: %s", container.ID, err)
+		}
+	}
+
+	if err := cluster.Stop(); err != nil {
+		t.Fatalf("cannot stop kafka cluster: %s", err)
+	}
+}


### PR DESCRIPTION
* make sure that connection error does not leave response waiters that are
  never consumed.
* proper message waiter closing
* do not generate more correlationIDs after closing connection

Related issue: https://github.com/optiopay/kafka/pull/13