### PR TITLE
when you kill instead of stop kafka, it does not recover

### DIFF
--- a/integration/broker_test.go
+++ b/integration/broker_test.go
@@ -60,8 +60,8 @@ func TestProducerBrokenConnection(t *testing.T) {
 	var stopped []*Container
 	for _, container := range containers {
 		if container.RunningKafka() {
-			if err := container.Stop(); err != nil {
-				t.Fatalf("cannot stop %q kafka container: %s", container.ID, err)
+			if err := container.Kill(); err != nil {
+				t.Fatalf("cannot kill %q kafka container: %s", container.ID, err)
 			}
 			stopped = append(stopped, container)
 		}

--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -67,6 +67,10 @@ func (c *Container) Stop() error {
 	return c.cluster.ContainerStop(c.ID)
 }
 
+func (c *Container) Kill() error {
+	return c.cluster.ContainerKill(c.ID)
+}
+
 // Start start zookeeper and kafka nodes using docker-compose command. Upon
 // successful process spawn, cluster is scaled to required amount of nodes.
 func (cluster *KafkaCluster) Start() error {
@@ -177,6 +181,14 @@ func (cluster *KafkaCluster) ContainerStop(containerID string) error {
 	stopCmd := cluster.cmd("docker", "stop", containerID)
 	if err := stopCmd.Run(); err != nil {
 		return fmt.Errorf("cannot stop %q container: %s", containerID, err)
+	}
+	return nil
+}
+
+func (cluster *KafkaCluster) ContainerKill(containerID string) error {
+	killCmd := cluster.cmd("docker", "kill", containerID)
+	if err := killCmd.Run(); err != nil {
+		return fmt.Errorf("cannot kill %q container: %s", containerID, err)
 	}
 	return nil
 }


### PR DESCRIPTION
If you use `container.Stop()`, the test passes. If you make some kafka nodes disappear via `container.Kill()`, the test fails reproducibly.