### PR TITLE
Randomize broker dialing

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"net"
 	"sync"
 	"syscall"
@@ -166,6 +167,11 @@ func Dial(nodeAddresses []string, conf BrokerConf) (*Broker, error) {
 		conns: make(map[int32]*connection),
 	}
 
+	if len(nodeAddresses) == 0 {
+		return nil, errors.New("no addresses provided")
+	}
+	numAddresses := len(nodeAddresses)
+
 	for i := 0; i < conf.DialRetryLimit; i++ {
 		if i > 0 {
 			conf.Logger.Debug("cannot fetch metadata from any connection",
@@ -174,7 +180,12 @@ func Dial(nodeAddresses []string, conf BrokerConf) (*Broker, error) {
 			time.Sleep(conf.DialRetryWait)
 		}
 
-		for _, addr := range nodeAddresses {
+		// This iterates starting at a random location in the slice, to prevent
+		// hitting the first server repeatedly
+		offset := rand.Intn(numAddresses)
+		for idx := 0; idx < numAddresses; idx++ {
+			addr := nodeAddresses[(idx+offset)%numAddresses]
+
 			conn, err := newTCPConnection(addr, conf.DialTimeout)
 			if err != nil {
 				conf.Logger.Debug("cannot connect",

--- a/server_test.go
+++ b/server_test.go
@@ -176,6 +176,8 @@ func (srv *Server) defaultRequestHandler(request Serializable) Serializable {
 	srv.mu.RLock()
 	defer srv.mu.RUnlock()
 
+	srv.Processed++
+
 	switch req := request.(type) {
 	case *proto.FetchReq:
 		resp := &proto.FetchResp{


### PR DESCRIPTION
When provided a list of brokers, this will round robin that list from
a random point. This is to prevent outages caused by everybody sharing
the same set of brokers and hammering the first broker with connects and
metadata requests.