### PR TITLE
Rename error key in logging

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -172,12 +172,12 @@ func (c *connection) Metadata(req *proto.MetadataReq) (*proto.MetadataResp, erro
 
 	respc, err := c.respWaiter(req.CorrelationID)
 	if err != nil {
-		c.logger.Error("msg", "failed waiting for response", "err", err)
+		c.logger.Error("msg", "failed waiting for response", "error", err)
 		return nil, fmt.Errorf("wait for response: %s", err)
 	}
 
 	if _, err := req.WriteTo(c.rw); err != nil {
-		c.logger.Error("msg", "cannot write", "err", err)
+		c.logger.Error("msg", "cannot write", "error", err)
 		c.releaseWaiter(req.CorrelationID)
 		return nil, err
 	}
@@ -205,12 +205,12 @@ func (c *connection) Produce(req *proto.ProduceReq) (*proto.ProduceResp, error) 
 
 	respc, err := c.respWaiter(req.CorrelationID)
 	if err != nil {
-		c.logger.Error("msg", "failed waiting for response", "err", err)
+		c.logger.Error("msg", "failed waiting for response", "error", err)
 		return nil, fmt.Errorf("wait for response: %s", err)
 	}
 
 	if _, err := req.WriteTo(c.rw); err != nil {
-		c.logger.Error("msg", "cannot write", "err", err)
+		c.logger.Error("msg", "cannot write", "error", err)
 		c.releaseWaiter(req.CorrelationID)
 		return nil, err
 	}
@@ -231,12 +231,12 @@ func (c *connection) Fetch(req *proto.FetchReq) (*proto.FetchResp, error) {
 
 	respc, err := c.respWaiter(req.CorrelationID)
 	if err != nil {
-		c.logger.Error("msg", "failed waiting for response", "err", err)
+		c.logger.Error("msg", "failed waiting for response", "error", err)
 		return nil, fmt.Errorf("wait for response: %s", err)
 	}
 
 	if _, err := req.WriteTo(c.rw); err != nil {
-		c.logger.Error("msg", "cannot write", "err", err)
+		c.logger.Error("msg", "cannot write", "error", err)
 		c.releaseWaiter(req.CorrelationID)
 		return nil, err
 	}
@@ -282,7 +282,7 @@ func (c *connection) Offset(req *proto.OffsetReq) (*proto.OffsetResp, error) {
 
 	respc, err := c.respWaiter(req.CorrelationID)
 	if err != nil {
-		c.logger.Error("msg", "failed waiting for response", "err", err)
+		c.logger.Error("msg", "failed waiting for response", "error", err)
 		return nil, fmt.Errorf("wait for response: %s", err)
 	}
 
@@ -290,7 +290,7 @@ func (c *connection) Offset(req *proto.OffsetReq) (*proto.OffsetResp, error) {
 	// -1 is for non node clients
 	req.ReplicaID = -1
 	if _, err := req.WriteTo(c.rw); err != nil {
-		c.logger.Error("msg", "cannot write", "err", err)
+		c.logger.Error("msg", "cannot write", "error", err)
 		c.releaseWaiter(req.CorrelationID)
 		return nil, err
 	}
@@ -308,11 +308,11 @@ func (c *connection) ConsumerMetadata(req *proto.ConsumerMetadataReq) (*proto.Co
 	}
 	respc, err := c.respWaiter(req.CorrelationID)
 	if err != nil {
-		c.logger.Error("msg", "failed waiting for response", "err", err)
+		c.logger.Error("msg", "failed waiting for response", "error", err)
 		return nil, fmt.Errorf("wait for response: %s", err)
 	}
 	if _, err := req.WriteTo(c.rw); err != nil {
-		c.logger.Error("msg", "cannot write", "err", err)
+		c.logger.Error("msg", "cannot write", "error", err)
 		c.releaseWaiter(req.CorrelationID)
 		return nil, err
 	}
@@ -330,11 +330,11 @@ func (c *connection) OffsetCommit(req *proto.OffsetCommitReq) (*proto.OffsetComm
 	}
 	respc, err := c.respWaiter(req.CorrelationID)
 	if err != nil {
-		c.logger.Error("msg", "failed waiting for response", "err", err)
+		c.logger.Error("msg", "failed waiting for response", "error", err)
 		return nil, fmt.Errorf("wait for response: %s", err)
 	}
 	if _, err := req.WriteTo(c.rw); err != nil {
-		c.logger.Error("msg", "cannot write", "err", err)
+		c.logger.Error("msg", "cannot write", "error", err)
 		c.releaseWaiter(req.CorrelationID)
 		return nil, err
 	}
@@ -352,11 +352,11 @@ func (c *connection) OffsetFetch(req *proto.OffsetFetchReq) (*proto.OffsetFetchR
 	}
 	respc, err := c.respWaiter(req.CorrelationID)
 	if err != nil {
-		c.logger.Error("msg", "failed waiting for response", "err", err)
+		c.logger.Error("msg", "failed waiting for response", "error", err)
 		return nil, fmt.Errorf("wait for response: %s", err)
 	}
 	if _, err := req.WriteTo(c.rw); err != nil {
-		c.logger.Error("msg", "cannot write", "err", err)
+		c.logger.Error("msg", "cannot write", "error", err)
 		c.releaseWaiter(req.CorrelationID)
 		return nil, err
 	}


### PR DESCRIPTION
While `err` is very well known for **errors** in Goland it is not in other contexts. 
This change is is driven to improving reporting capabilities with log analytic tools like ELK stack and others.
At optiopay we're changing services to use `error` key only. 
Feedback is welcome /cc @zorkian  @cespare @dmage