### PR TITLE
Remove topic/partition from metadata cache

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -438,6 +438,7 @@ func (b *Broker) muLeaderConnection(topic string, partition int32) (conn *connec
 				b.conf.Logger.Info("cannot get leader connection: no information about node",
 					"nodeID", nodeID)
 				err = proto.ErrBrokerNotAvailable
+				delete(b.metadata.endpoints, tp)
 				continue
 			}
 			conn, err = newTCPConnection(addr, b.conf.DialTimeout)
@@ -445,6 +446,7 @@ func (b *Broker) muLeaderConnection(topic string, partition int32) (conn *connec
 				b.conf.Logger.Info("cannot get leader connection: cannot connect to node",
 					"address", addr,
 					"error", err)
+				delete(b.metadata.endpoints, tp)
 				continue
 			}
 			b.conns[nodeID] = conn


### PR DESCRIPTION
Remove pair topic and partition from endpoints to avoid wrong data getting stuck
in the metadata cache. Situation when leader is present in the endpoints, but
we can't connect to him means that it is a dead connection and we have
old metadata.

Signed-off-by: Alexey Gladkov <gladkov.alexey@gmail.com>