### PR TITLE
hashProducer doesn't respect p.partitions

### DIFF
--- a/distributing_producer.go
+++ b/distributing_producer.go
@@ -136,5 +136,5 @@ func (p *hashProducer) messagePartition(m *proto.Message) (int32, error) {
 	if sum < 0 {
 		sum = -sum
 	}
-	return sum / p.partitions, nil
+	return sum % p.partitions, nil
 }


### PR DESCRIPTION
Need to use % instead of / to avoid returning partitions > p.partitions