### PR TITLE
randomProducer panics when given empty partitions

### DIFF
--- a/distributing_producer.go
+++ b/distributing_producer.go
@@ -42,6 +42,9 @@ func NewRandomProducer(p Producer, numPartitions int32) DistributingProducer {
 // partition. All messages written within single Produce call are atomically
 // written to the same destination.
 func (p *randomProducer) Distribute(topic string, messages ...*proto.Message) (offset int64, err error) {
+	// In the case there are no partitions, which may happen for new topics
+	// when AllowTopicCreation is passed, we will write to partition 0
+	// since rand.Intn panics with 0
 	part := 0
 	if p.partitions > 0 {
 		part = p.rand.Intn(int(p.partitions))

--- a/distributing_producer.go
+++ b/distributing_producer.go
@@ -42,7 +42,10 @@ func NewRandomProducer(p Producer, numPartitions int32) DistributingProducer {
 // partition. All messages written within single Produce call are atomically
 // written to the same destination.
 func (p *randomProducer) Distribute(topic string, messages ...*proto.Message) (offset int64, err error) {
-	part := p.rand.Intn(int(p.partitions))
+	part := 0
+	if p.partitions > 0 {
+		part = p.rand.Intn(int(p.partitions))
+	}
 	return p.producer.Produce(topic, int32(part), messages...)
 }
 


### PR DESCRIPTION
When producing messages using option AllowTopicCreation, the number of partitions for the topic will be 0 initially causing randomProducer to panic when producing the messages since Intn panics on 0. This fixes the issue