### PR TITLE
Introduce channel producer.

### DIFF
--- a/distributing_producer.go
+++ b/distributing_producer.go
@@ -52,6 +52,134 @@ func (p *randomProducer) Distribute(topic string, messages ...*proto.Message) (o
 	return p.producer.Produce(topic, int32(part), messages...)
 }
 
+type backOffType struct {
+	initialWaitTime time.Duration
+	exp             float64
+	nextWaitTime    time.Duration
+}
+
+func newBackOffType(initial time.Duration, exp float64) *backOffType {
+	return &backOffType{
+		initialWaitTime: initial,
+		exp:             exp,
+		nextWaitTime:    initial,
+	}
+}
+
+func (b *backOffType) WaitTime(err error) (waitTime time.Duration) {
+	if err == nil {
+		b.nextWaitTime = b.initialWaitTime
+		return
+	}
+	waitTime = b.nextWaitTime
+	b.nextWaitTime = time.Duration(float64(b.nextWaitTime) * b.exp)
+	return
+}
+
+type channelTopicProducerResponseType struct {
+	Offset int64
+	Error  error
+}
+
+type channelTopicProducerRequestType struct {
+	Messages []*proto.Message
+	Response chan channelTopicProducerResponseType
+}
+
+type channelTopicProducerType struct {
+	topic    string
+	producer Producer
+	ch       chan channelTopicProducerRequestType
+}
+
+func newChannelTopicProducer(
+	topic string,
+	p Producer,
+	numPartitions int32) *channelTopicProducerType {
+	result := &channelTopicProducerType{
+		topic:    topic,
+		producer: p,
+		ch: make(
+			chan channelTopicProducerRequestType, numPartitions),
+	}
+	partitionCount := int(numPartitions)
+	for i := 0; i < partitionCount; i++ {
+		go result.consumePartition(i)
+	}
+	return result
+}
+
+func (p *channelTopicProducerType) consumePartition(partition int) {
+	backoff := newBackOffType(10*time.Second, 1.5)
+	for {
+		request := <-p.ch
+		var response channelTopicProducerResponseType
+		response.Offset, response.Error = p.producer.Produce(
+			p.topic, int32(partition), request.Messages...)
+		request.Response <- response
+		close(request.Response)
+		waitTime := backoff.WaitTime(response.Error)
+		if waitTime > 0 {
+			time.Sleep(waitTime)
+		}
+	}
+}
+
+func (p *channelTopicProducerType) Distribute(messages ...*proto.Message) (
+	offset int64, err error) {
+	responseCh := make(chan channelTopicProducerResponseType)
+	p.ch <- channelTopicProducerRequestType{
+		Messages: messages,
+		Response: responseCh,
+	}
+	response := <-responseCh
+	return response.Offset, response.Error
+}
+
+type channelProducer struct {
+	producer   Producer
+	partitions int32
+	mu         sync.Mutex
+	topicMap   map[string]*channelTopicProducerType
+}
+
+// NewChannelProducer wraps given producer and returns a
+// DistributingProducer that works like a random producer plus it
+// guarantees that if only X% of KAFKA endpoints are up, writing throughput
+// will eventually approach X%.
+// The returned DistributingProducer accomplishes this by favoring destinations
+// that accept writes over ones that continually produce errors.
+func NewChannelProducer(p Producer, numPartitions int32) DistributingProducer {
+	return &channelProducer{
+		producer:   p,
+		partitions: numPartitions,
+		topicMap:   make(map[string]*channelTopicProducerType),
+	}
+}
+
+func (p *channelProducer) fetchTopicProducer(topic string) (
+	result *channelTopicProducerType) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	result = p.topicMap[topic]
+	if result == nil {
+		result = newChannelTopicProducer(
+			topic, p.producer, p.partitions)
+		p.topicMap[topic] = result
+	}
+	return
+}
+
+// Distribute writes messages to given kafka topic, choosing
+// a destination at random but favoring destinations that accept writes
+// rather than producing errors.
+// All messages written within single Produce call are atomically
+// written to the same destination.
+func (p *channelProducer) Distribute(
+	topic string, messages ...*proto.Message) (offset int64, err error) {
+	return p.fetchTopicProducer(topic).Distribute(messages...)
+}
+
 type roundRobinProducer struct {
 	producer   Producer
 	partitions int32


### PR DESCRIPTION
I took the liberty of trying out a new Distributing producer that works like random producer, but favors destinations that accept messages rather than producing errors.

I create a goroutine for each (topic, partitionNo) pair. If a goroutine encounters persistent errors writing to its topic and partition, it accepts new jobs less and less often using exponential back off. By accepting jobs less frequently, a goroutine encountering persistent errors leaves jobs available to goroutines that write successfully. Ultimately this strategy increases write throughput.

For my environment where I have one out of 5 KAFKA destinations permanently down, this strategy increases my write throughput by at least an order of magnitude. My application receives messages from various sources and writes them out to KAFKA. Using a round robin distributor, my application was unable to write data to KAFKA as fast as it was receiving data (80 thousand messages written for 1 million messages received). With this new channel producer, my application is able to write messages out to KAFKA as fast as it receives them in spite of persistent failures. At the beginning, my application falls behind as it tries to write to the failed destination, but within a few minutes, it catches up as the goroutines encountering errors eventually quit taking work.

This new distributing producer can only be used when each message can be written to any partition. 