### PR TITLE
Fix warnings from various linters (golint, vet...)

### DIFF
--- a/broker_test.go
+++ b/broker_test.go
@@ -75,7 +75,7 @@ func (m *MetadataTester) Handler() RequestHandler {
 			wantsTopic[topic] = true
 		}
 
-		for topic, _ := range m.topics {
+		for topic := range m.topics {
 			// Return either all topics or only topics that they explicitly requested
 			_, explicitTopic := wantsTopic[topic]
 			if len(req.Topics) > 0 && !explicitTopic {
@@ -1137,7 +1137,7 @@ func TestLeaderConnectionFailover(t *testing.T) {
 		2: fmt.Sprintf("%s:%d", host2, port2),
 	}
 
-	conn, err = broker.muLeaderConnection("test", 0)
+	_, err = broker.muLeaderConnection("test", 0)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}

--- a/distributing_producer_test.go
+++ b/distributing_producer_test.go
@@ -54,9 +54,9 @@ func TestRoundRobinProducer(t *testing.T) {
 	}
 
 	for i, values := range data {
-		msgs := make([]*proto.Message, 0)
-		for _, value := range values {
-			msgs = append(msgs, &proto.Message{Value: value})
+		msgs := make([]*proto.Message, len(values))
+		for i, value := range values {
+			msgs[i] = &proto.Message{Value: value}
 		}
 		if _, err := p.Distribute("test-topic", msgs...); err != nil {
 			t.Errorf("cannot distribute %d message: %s", i, err)

--- a/multiplexer.go
+++ b/multiplexer.go
@@ -49,7 +49,7 @@ func Merge(consumers ...Consumer) *Mx {
 		go func(c Consumer) {
 			defer func() {
 				p.mu.Lock()
-				p.workers -= 1
+				p.workers--
 				if p.workers == 0 && !p.closed {
 					close(p.stop)
 					p.closed = true


### PR DESCRIPTION
I cleaned the code a little following advice from linters.

The reordering of `ProducerConf` was because of a warning of [aligncheck](https://github.com/opennota/check). It optimizes the size of the struct in memory. See [here for a visual explanation](http://golang-sizeof.tips/?t=Ly8gU2ltcGxpZmllZCBQcm9kdWNlckNvbmYuCnN0cnVjdCB7CglDb21wcmVzc2lvbiBpbnQ4CglSZXF1aXJlZEFja3MgaW50MTYKCVJlcXVlc3RUaW1lb3V0IGludDY0Cn0K).
But I can remove this optimization if you are not confortable with it.