### PR TITLE
Fix Consumer leader change failure

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -1196,7 +1196,11 @@ consumeRetryLoop:
 					continue
 				}
 				switch part.Err {
-				case proto.ErrLeaderNotAvailable, proto.ErrNotLeaderForPartition, proto.ErrBrokerNotAvailable:
+				case proto.ErrLeaderNotAvailable,
+					proto.ErrNotLeaderForPartition,
+					proto.ErrBrokerNotAvailable,
+					proto.ErrUnknownTopicOrPartition:
+
 					c.conf.Logger.Debug("cannot fetch messages",
 						"retry", retry,
 						"error", part.Err)

--- a/broker_test.go
+++ b/broker_test.go
@@ -1468,6 +1468,10 @@ func TestConsumeWhileLeaderChange(t *testing.T) {
 				},
 			}
 		}
+		respErr := proto.ErrNotLeaderForPartition
+		if fetch1Calls > 2 {
+			respErr = proto.ErrUnknownTopicOrPartition
+		}
 		return &proto.FetchResp{
 			CorrelationID: req.CorrelationID,
 			Topics: []proto.FetchRespTopic{
@@ -1476,7 +1480,7 @@ func TestConsumeWhileLeaderChange(t *testing.T) {
 					Partitions: []proto.FetchRespPartition{
 						{
 							ID:  1,
-							Err: proto.ErrNotLeaderForPartition,
+							Err: respErr,
 						},
 					},
 				},


### PR DESCRIPTION
If the leader for a partition becomes a follower for that partition,
then a fetch request returns ErrNotLeaderForPartition. The Consumer
properly handled this case and refreshed metadata.

If the leader for a partition hands off the partition entirely and is no
longer a broker for that partition, it will instead return
ErrUnknownTopicOrPartition. In this case, the Consumer returned the
error and never refreshed metadata, which means that the Consumer is
stuck.

This problem can be reproduced by creating a Kafka cluster with 2 nodes.
Make a single topic with 1 partition and 1 replica. Start consuming,
then force a leader change.