### PR TITLE
Set TCP keep-alive on all connections

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -31,7 +31,11 @@ type connection struct {
 
 // newConnection returns new, initialized connection or error
 func newTCPConnection(address string, timeout time.Duration) (*connection, error) {
-	conn, err := net.DialTimeout("tcp", address, timeout)
+	dialer := net.Dialer{
+		Timeout:   timeout,
+		KeepAlive: 30 * time.Second,
+	}
+	conn, err := dialer.Dial("tcp", address)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If a broker completely goes away without closing the TCP connection, it can leave the client connection hung indefinitely. For example, here's a stack trace from a consumer that was hung in IO wait for 56 hours after the broker died (even though we replaced the dead broker with a new one within a few hours of it dying):

```
    net     netpoll.go:160        runtime_pollWait(*, 0x72, *)
    net     fd_poll_runtime.go:73 (*pollDesc).Wait(*, 0x72, 0, 0)
    net     fd_poll_runtime.go:78 (*pollDesc).WaitRead(*, 0, 0)
    net     fd_unix.go:250        (*netFD).Read(*, *, 0x1000, 0x1000, 0, #727, #63)
    net     net.go:172            (*conn).Read(*, *, 0x1000, 0x1000, 0, 0, 0)
    bufio   bufio.go:97           (*Reader).fill(*)
    bufio   bufio.go:207          (*Reader).Read(*, *, 0x4, 0x400, 0x4, 0, 0)
    io      io.go:297             ReadAtLeast(#725, *, *, 0x4, 0x400, 0x4, 0, 0, 0)
    io      io.go:315             ReadFull(#725, *, *, 0x4, 0x400, 0x400, 0, 0)
    proto   serialization.go:64   (*decoder).DecodeInt32(*, 0x400)
    proto   messages.go:87        ReadResp(#725, *, *, 0, 0, 0, 0, 0)
    kafka   connection.go:83      (*connection).readRespLoop(*)
```

The best solution is probably to set a deadline before every connection read/write. As a quick fix, though, we can use TCP keep-alive to detect dead connections.

For now, just unconditionally set a 30s keep-alive on every connection. If people want to customize this, we could add a tunable for disabling keep-alives or changing the interval.