### PR TITLE
fix concurrent map writes

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -630,7 +630,7 @@ func (b *Broker) offset(topic string, partition int32, timems int64) (offset int
 	for retry := 0; retry < b.conf.RetryErrLimit; retry++ {
 		if retry != 0 {
 			time.Sleep(b.conf.RetryErrWait)
-			err = b.refreshMetadata()
+			err = b.muRefreshMetadata()
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
call muRefreshMetada instead of refreshMetadata to prevent the following panic

fatal error: concurrent map writes
 
goroutine 871 [running]:
runtime.throw(0x8ca75e, 0x15)
	/home/marko/go/src/runtime/panic.go:596 +0x95 fp=0xd8226e3660 sp=0xd8226e3640
runtime.mapassign(0x83f520, 0xd8b8885590, 0xd8226e3850, 0x10)
	/home/marko/go/src/runtime/hashmap.go:499 +0x667 fp=0xd8226e3700 sp=0xd8226e3660
badoo/vendor/github.com/optiopay/kafka.(*Broker).cacheMetadata(0xc4202de680, 0xd346ad18c0)
	/home/marko/goprojects/src/badoo/vendor/github.com/optiopay/kafka/broker.go:387 +0x786 fp=0xd8226e39f8 sp=0xd8226e3700
badoo/vendor/github.com/optiopay/kafka.(*Broker).refreshMetadata(0xc4202de680, 0xc42146a0c0, 0x25)
	/home/marko/goprojects/src/badoo/vendor/github.com/optiopay/kafka/broker.go:269 +0x8f fp=0xd8226e3a50 sp=0xd8226e39f8
badoo/vendor/github.com/optiopay/kafka.(*Broker).offset(0xc4202de680, 0xc42018e6c0, 0x14, 0x31, 0xfffffffffffffffe, 0xc420842d88, 0x3, 0x3)
	/home/marko/goprojects/src/badoo/vendor/github.com/optiopay/kafka/broker.go:633 +0xc4 fp=0xd8226e3ca0 sp=0xd8226e3a50
badoo/vendor/github.com/optiopay/kafka.(*Broker).OffsetEarliest(0xc4202de680, 0xc42018e6c0, 0x14, 0x31, 0x3, 0xc420842f40, 0xc42141a098)
	/home/marko/goprojects/src/badoo/vendor/github.com/optiopay/kafka/broker.go:703 +0x50 fp=0xd8226e3cf0 sp=0xd8226e3ca0