### PR TITLE
add logging upon retry, and log the successfull final retransmission

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -786,6 +786,11 @@ func (p *producer) Produce(topic string, partition int32, messages ...*proto.Mes
 			for i, msg := range messages {
 				msg.Offset = int64(i) + offset
 			}
+			if retry != 0 {
+				p.conf.Logger.Debug("Produced message after retry",
+					"retry", retry,
+					"topic", topic)
+			}
 			return offset, err
 		case io.EOF, syscall.EPIPE:
 			// p.produce call is closing connection when this error shows up,
@@ -804,12 +809,9 @@ func (p *producer) Produce(topic string, partition int32, messages ...*proto.Mes
 			"topic", topic,
 			"error", err)
 	}
-	if retry != 0 {
-		p.conf.Logger.Debug("Produced message after retry",
-			"retry", retry,
-			"topic", topic,
-			"error", err)
-	}
+	p.conf.Logger.Debug("Abort to produce after retrying messages",
+		"retry", retry,
+		"topic", topic)
 	return 0, err
 
 }

--- a/broker.go
+++ b/broker.go
@@ -773,8 +773,7 @@ func (b *Broker) Producer(conf ProducerConf) Producer {
 //
 // Upon a successful call, the message's Offset field is updated.
 func (p *producer) Produce(topic string, partition int32, messages ...*proto.Message) (offset int64, err error) {
-	retry := 0
-	for retry = 0; retry < p.conf.RetryLimit; retry++ {
+	for retry := 0; retry < p.conf.RetryLimit; retry++ {
 		if retry != 0 {
 			time.Sleep(p.conf.RetryWait)
 		}
@@ -810,7 +809,7 @@ func (p *producer) Produce(topic string, partition int32, messages ...*proto.Mes
 			"error", err)
 	}
 	p.conf.Logger.Debug("Abort to produce after retrying messages",
-		"retry", retry,
+		"retry", p.conf.RetryLimit,
 		"topic", topic)
 	return 0, err
 

--- a/broker.go
+++ b/broker.go
@@ -773,8 +773,8 @@ func (b *Broker) Producer(conf ProducerConf) Producer {
 //
 // Upon a successful call, the message's Offset field is updated.
 func (p *producer) Produce(topic string, partition int32, messages ...*proto.Message) (offset int64, err error) {
-
-	for retry := 0; retry < p.conf.RetryLimit; retry++ {
+	retry := 0
+	for retry = 0; retry < p.conf.RetryLimit; retry++ {
 		if retry != 0 {
 			time.Sleep(p.conf.RetryWait)
 		}
@@ -799,11 +799,17 @@ func (p *producer) Produce(topic string, partition int32, messages ...*proto.Mes
 					"error", err)
 			}
 		}
-		p.conf.Logger.Debug("cannot produce messages",
+		p.conf.Logger.Debug("Cannot produce messages",
 			"retry", retry,
+			"topic", topic,
 			"error", err)
 	}
-
+	if retry != 0 {
+		p.conf.Logger.Debug("Produced message after retry",
+			"retry", retry,
+			"topic", topic,
+			"error", err)
+	}
 	return 0, err
 
 }


### PR DESCRIPTION
When a producer tries to write a message to Kafka and fails. A retry loop will attempt to rewrite the message.The final successful attempt is never logger. 

This pull request add a log line upon a successful write following a failure.