### PR TITLE
Made `version` member of Request and Response in order to avoid passi…

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -188,7 +188,7 @@ func (c *connection) Metadata(req *proto.MetadataReq) (*proto.MetadataResp, erro
 		return nil, fmt.Errorf("wait for response: %s", err)
 	}
 
-	if _, err := req.WriteTo(c.rw, req.Version); err != nil {
+	if _, err := req.WriteTo(c.rw); err != nil {
 		c.logger.Error("msg", "cannot write", "error", err)
 		c.releaseWaiter(req.CorrelationID)
 		return nil, err
@@ -211,7 +211,7 @@ func (c *connection) Produce(req *proto.ProduceReq) (*proto.ProduceResp, error) 
 	}
 
 	if req.RequiredAcks == proto.RequiredAcksNone {
-		_, err := req.WriteTo(c.rw, req.Version)
+		_, err := req.WriteTo(c.rw)
 		return nil, err
 	}
 
@@ -221,7 +221,7 @@ func (c *connection) Produce(req *proto.ProduceReq) (*proto.ProduceResp, error) 
 		return nil, fmt.Errorf("wait for response: %s", err)
 	}
 
-	if _, err := req.WriteTo(c.rw, req.Version); err != nil {
+	if _, err := req.WriteTo(c.rw); err != nil {
 		c.logger.Error("msg", "cannot write", "error", err)
 		c.releaseWaiter(req.CorrelationID)
 		return nil, err
@@ -247,7 +247,7 @@ func (c *connection) Fetch(req *proto.FetchReq) (*proto.FetchResp, error) {
 		return nil, fmt.Errorf("wait for response: %s", err)
 	}
 
-	if _, err := req.WriteTo(c.rw, req.Version); err != nil {
+	if _, err := req.WriteTo(c.rw); err != nil {
 		c.logger.Error("msg", "cannot write", "error", err)
 		c.releaseWaiter(req.CorrelationID)
 		return nil, err
@@ -301,7 +301,7 @@ func (c *connection) Offset(req *proto.OffsetReq) (*proto.OffsetResp, error) {
 	// TODO(husio) documentation is not mentioning this directly, but I assume
 	// -1 is for non node clients
 	req.ReplicaID = -1
-	if _, err := req.WriteTo(c.rw, req.Version); err != nil {
+	if _, err := req.WriteTo(c.rw); err != nil {
 		c.logger.Error("msg", "cannot write", "error", err)
 		c.releaseWaiter(req.CorrelationID)
 		return nil, err
@@ -323,7 +323,7 @@ func (c *connection) ConsumerMetadata(req *proto.ConsumerMetadataReq) (*proto.Co
 		c.logger.Error("msg", "failed waiting for response", "error", err)
 		return nil, fmt.Errorf("wait for response: %s", err)
 	}
-	if _, err := req.WriteTo(c.rw, req.Version); err != nil {
+	if _, err := req.WriteTo(c.rw); err != nil {
 		c.logger.Error("msg", "cannot write", "error", err)
 		c.releaseWaiter(req.CorrelationID)
 		return nil, err
@@ -345,7 +345,7 @@ func (c *connection) OffsetCommit(req *proto.OffsetCommitReq) (*proto.OffsetComm
 		c.logger.Error("msg", "failed waiting for response", "error", err)
 		return nil, fmt.Errorf("wait for response: %s", err)
 	}
-	if _, err := req.WriteTo(c.rw, req.Version); err != nil {
+	if _, err := req.WriteTo(c.rw); err != nil {
 		c.logger.Error("msg", "cannot write", "error", err)
 		c.releaseWaiter(req.CorrelationID)
 		return nil, err
@@ -367,7 +367,7 @@ func (c *connection) OffsetFetch(req *proto.OffsetFetchReq) (*proto.OffsetFetchR
 		c.logger.Error("msg", "failed waiting for response", "error", err)
 		return nil, fmt.Errorf("wait for response: %s", err)
 	}
-	if _, err := req.WriteTo(c.rw, req.Version); err != nil {
+	if _, err := req.WriteTo(c.rw); err != nil {
 		c.logger.Error("msg", "cannot write", "error", err)
 		c.releaseWaiter(req.CorrelationID)
 		return nil, err

--- a/connection_test.go
+++ b/connection_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 type serializableMessage interface {
-	Bytes(int16) ([]byte, error)
+	Bytes() ([]byte, error)
 }
 
 func testServer(messages ...serializableMessage) (net.Listener, error) {
@@ -22,7 +22,7 @@ func testServer(messages ...serializableMessage) (net.Listener, error) {
 
 	responses := make([][]byte, len(messages))
 	for i, m := range messages {
-		b, err := m.Bytes(proto.KafkaV0)
+		b, err := m.Bytes()
 		if err != nil {
 			_ = ln.Close()
 			return nil, err
@@ -68,7 +68,7 @@ func testServer2() (net.Listener, chan serializableMessage, error) {
 				defer func() { _ = cli.Close() }()
 
 				for msg := range msgs {
-					b, err := msg.Bytes(proto.KafkaV0)
+					b, err := msg.Bytes()
 					if err != nil {
 						panic(err)
 					}

--- a/kafkatest/server.go
+++ b/kafkatest/server.go
@@ -337,6 +337,7 @@ func (s *Server) handleProduceRequest(nodeID int32, conn net.Conn, req *proto.Pr
 	defer s.mu.Unlock()
 
 	resp := &proto.ProduceResp{
+		Version:       req.Version,
 		CorrelationID: req.CorrelationID,
 		Topics:        make([]proto.ProduceRespTopic, len(req.Topics)),
 	}
@@ -380,6 +381,7 @@ func (s *Server) fetchRequest(req *proto.FetchReq) (response, int) {
 	var messagesNum int
 
 	resp := &proto.FetchResp{
+		Version:       req.Version,
 		CorrelationID: req.CorrelationID,
 		Topics:        make([]proto.FetchRespTopic, len(req.Topics)),
 	}
@@ -430,6 +432,7 @@ func (s *Server) handleOffsetRequest(nodeID int32, conn net.Conn, req *proto.Off
 	defer s.mu.RUnlock()
 
 	resp := &proto.OffsetResp{
+		Version:       req.Version,
 		CorrelationID: req.CorrelationID,
 		Topics:        make([]proto.OffsetRespTopic, len(req.Topics)),
 	}
@@ -462,6 +465,7 @@ func (s *Server) handleConsumerMetadataRequest(nodeID int32, conn net.Conn, req 
 	port, _ := strconv.Atoi(addrps[1])
 
 	return &proto.ConsumerMetadataResp{
+		Version:         req.Version,
 		CorrelationID:   req.CorrelationID,
 		CoordinatorID:   0,
 		CoordinatorHost: addrps[0],
@@ -496,6 +500,7 @@ func (s *Server) handleOffsetFetchRequest(nodeID int32, conn net.Conn, req *prot
 	defer s.mu.RUnlock()
 
 	resp := &proto.OffsetFetchResp{
+		Version:       req.Version,
 		CorrelationID: req.CorrelationID,
 		Topics:        make([]proto.OffsetFetchRespTopic, len(req.Topics)),
 	}
@@ -518,6 +523,7 @@ func (s *Server) handleOffsetCommitRequest(nodeID int32, conn net.Conn, req *pro
 	defer s.mu.Unlock()
 
 	resp := &proto.OffsetCommitResp{
+		Version:       req.Version,
 		CorrelationID: req.CorrelationID,
 		Topics:        make([]proto.OffsetCommitRespTopic, len(req.Topics)),
 	}

--- a/proto/messages_go_1.8_test.go
+++ b/proto/messages_go_1.8_test.go
@@ -57,7 +57,7 @@ func TestProduceRequest(t *testing.T) {
 	for _, tt := range tests {
 		req.Compression = tt.Compression
 		testRequestSerialization(t, req)
-		b, _ := req.Bytes(KafkaV0)
+		b, _ := req.Bytes()
 
 		if !bytes.Equal(b, tt.Expected) {
 			fmt.Printf("%#v\n", tt.Expected)

--- a/proto/messages_test.go
+++ b/proto/messages_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 type Request interface {
-	Bytes(version int16) ([]byte, error)
-	WriteTo(w io.Writer, version int16) (int64, error)
+	Bytes() ([]byte, error)
+	WriteTo(w io.Writer) (int64, error)
 }
 
 var _ Request = &MetadataReq{}
@@ -23,12 +23,12 @@ var _ Request = &OffsetFetchReq{}
 
 func testRequestSerialization(t *testing.T, r Request) {
 	var buf bytes.Buffer
-	if n, err := r.WriteTo(&buf, KafkaV0); err != nil {
+	if n, err := r.WriteTo(&buf); err != nil {
 		t.Fatalf("could not write request to buffer: %s", err)
 	} else if n != int64(buf.Len()) {
 		t.Fatalf("writer returned invalid number of bytes written %d != %d", n, buf.Len())
 	}
-	b, err := r.Bytes(KafkaV0)
+	b, err := r.Bytes()
 	if err != nil {
 		t.Fatalf("could not convert request to bytes: %s", err)
 	}
@@ -42,9 +42,10 @@ func TestMetadataRequest(t *testing.T) {
 		CorrelationID: 123,
 		ClientID:      "testcli",
 		Topics:        nil,
+		Version:       KafkaV0,
 	}
 	testRequestSerialization(t, req1)
-	b, _ := req1.Bytes(KafkaV0)
+	b, _ := req1.Bytes()
 	expected := []byte{0x0, 0x0, 0x0, 0x15, 0x0, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x7b, 0x0, 0x7, 0x74, 0x65, 0x73, 0x74, 0x63, 0x6c, 0x69, 0x0, 0x0, 0x0, 0x0}
 
 	if !bytes.Equal(b, expected) {
@@ -57,7 +58,7 @@ func TestMetadataRequest(t *testing.T) {
 		Topics:        []string{"foo", "bar"},
 	}
 	testRequestSerialization(t, req2)
-	b, _ = req2.Bytes(KafkaV0)
+	b, _ = req2.Bytes()
 	expected = []byte{0x0, 0x0, 0x0, 0x1f, 0x0, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x7b, 0x0, 0x7, 0x74, 0x65, 0x73, 0x74, 0x63, 0x6c, 0x69, 0x0, 0x0, 0x0, 0x2, 0x0, 0x3, 0x66, 0x6f, 0x6f, 0x0, 0x3, 0x62, 0x61, 0x72}
 
 	if !bytes.Equal(b, expected) {
@@ -67,6 +68,21 @@ func TestMetadataRequest(t *testing.T) {
 	r, _ := ReadMetadataReq(bytes.NewBuffer(expected))
 	if !reflect.DeepEqual(r, req2) {
 		t.Fatalf("malformed request: %#v", r)
+	}
+
+	req3 := &MetadataReq{
+		CorrelationID:          123,
+		ClientID:               "testcli",
+		Topics:                 nil,
+		Version:                KafkaV4,
+		AllowAutoTopicCreation: true,
+	}
+	testRequestSerialization(t, req3)
+	b3, _ := req3.Bytes()
+	expected3 := []byte{0x0, 0x0, 0x0, 0x16, 0x0, 0x3, 0x0, 0x4, 0x0, 0x0, 0x0, 0x7b, 0x0, 0x7, 0x74, 0x65, 0x73, 0x74, 0x63, 0x6c, 0x69, 0x0, 0x0, 0x0, 0x0, 0x1}
+
+	if !bytes.Equal(b3, expected3) {
+		t.Fatalf("expected different bytes representation: %v ( expected %v)", b3, expected3)
 	}
 }
 
@@ -112,7 +128,7 @@ func TestMetadataResponse(t *testing.T) {
 		t.Fatalf("expected different message: %#v", resp)
 	}
 
-	if b, err := resp.Bytes(KafkaV0); err != nil {
+	if b, err := resp.Bytes(); err != nil {
 		t.Fatalf("cannot serialize response: %s", err)
 	} else {
 		if !bytes.Equal(b, msgb) {
@@ -146,7 +162,7 @@ func TestProduceResponse(t *testing.T) {
 		t.Fatalf("expected different message: %#v", resp1)
 	}
 
-	if b, err := resp1.Bytes(KafkaV0); err != nil {
+	if b, err := resp1.Bytes(); err != nil {
 		t.Fatalf("cannot serialize response: %s", err)
 	} else {
 		if !bytes.Equal(b, msgb1) {
@@ -177,7 +193,7 @@ func TestProduceResponse(t *testing.T) {
 	if !reflect.DeepEqual(resp2, expected2) {
 		t.Fatalf("expected different message: %#v", resp2)
 	}
-	if b, err := resp2.Bytes(KafkaV0); err != nil {
+	if b, err := resp2.Bytes(); err != nil {
 		t.Fatalf("cannot serialize response: %s", err)
 	} else {
 		if !bytes.Equal(b, msgb2) {
@@ -204,7 +220,7 @@ func TestFetchRequest(t *testing.T) {
 		},
 	}
 	testRequestSerialization(t, req)
-	b, _ := req.Bytes(KafkaV0)
+	b, _ := req.Bytes()
 	expected := []byte{0x0, 0x0, 0x0, 0x47, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf1, 0x0, 0x4, 0x74, 0x65, 0x73, 0x74, 0xff, 0xff, 0xff, 0xff, 0x0, 0x0, 0x7, 0xd0, 0x0, 0x0, 0x30, 0xa6, 0x0, 0x0, 0x0, 0x1, 0x0, 0x3, 0x66, 0x6f, 0x6f, 0x0, 0x0, 0x0, 0x2, 0x0, 0x0, 0x1, 0xa5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2, 0x11, 0x0, 0x0, 0x13, 0x39, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xb, 0x0, 0x0, 0x0, 0x5c}
 
 	if !bytes.Equal(b, expected) {
@@ -307,7 +323,7 @@ func TestFetchResponse(t *testing.T) {
 			t.Fatalf("expected different message: %#v", resp)
 		}
 		if tt.RoundTrip {
-			b, err := resp.Bytes(KafkaV0)
+			b, err := resp.Bytes()
 			if err != nil {
 				t.Fatalf("cannot serialize response: %s", err)
 			}
@@ -411,7 +427,7 @@ func BenchmarkProduceRequestMarshal(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		if _, err := req.Bytes(KafkaV0); err != nil {
+		if _, err := req.Bytes(); err != nil {
 			b.Fatalf("could not serialize messages: %s", err)
 		}
 	}
@@ -433,7 +449,7 @@ func BenchmarkProduceResponseUnmarshal(b *testing.B) {
 			},
 		},
 	}
-	raw, err := resp.Bytes(KafkaV0)
+	raw, err := resp.Bytes()
 	if err != nil {
 		b.Fatalf("cannot serialize response: %s", err)
 	}
@@ -465,7 +481,7 @@ func BenchmarkFetchRequestMarshal(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		if _, err := req.Bytes(KafkaV0); err != nil {
+		if _, err := req.Bytes(); err != nil {
 			b.Fatalf("could not serialize messages: %s", err)
 		}
 	}
@@ -502,7 +518,7 @@ func BenchmarkFetchResponseUnmarshal(b *testing.B) {
 			},
 		},
 	}
-	raw, err := resp.Bytes(KafkaV0)
+	raw, err := resp.Bytes()
 	if err != nil {
 		b.Fatalf("cannot serialize response: %s", err)
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -23,7 +23,7 @@ const (
 )
 
 type Serializable interface {
-	Bytes(int16) ([]byte, error)
+	Bytes() ([]byte, error)
 }
 
 type RequestHandler func(request Serializable) (response Serializable)
@@ -161,7 +161,7 @@ func (srv *Server) handleClient(c net.Conn) {
 
 		response := fn(request)
 		if response != nil {
-			b, err := response.Bytes(proto.KafkaV0)
+			b, err := response.Bytes()
 			if err != nil {
 				panic(fmt.Sprintf("cannot serialize %T: %s", response, err))
 			}


### PR DESCRIPTION
Currently, we pass `version` argument in the Bytes method for every Request/Response.
In this PR we use `Version` field from Req/Resp structure instead of passing it explicitly in every method.   I've added this field to every structure which missed it. 