### PR TITLE
fixed bug in OffsetResponse

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -619,6 +619,9 @@ func TestOffsetResponseWithVersions(t *testing.T) {
 	ts := time.Unix(0, (time.Now().UnixNano()/int64(time.Millisecond))*int64(time.Millisecond))
 	resp1.Topics[0].Partitions[0].TimeStamp = ts
 
+	// In kafka >= KafkaV1 there might be only one offset
+	resp1.Topics[0].Partitions[0].Offsets = []int64{92}
+
 	b1, err := resp1.Bytes()
 	if err != nil {
 		t.Fatal(err)

--- a/integration/broker_test.go
+++ b/integration/broker_test.go
@@ -74,6 +74,25 @@ func TestProduceAndConsume(t *testing.T) {
 		}
 	}
 
+	// check if offsets are correct
+	for _, name := range topics {
+		offe, err := broker.OffsetEarliest(name, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if offe != 0 {
+			t.Fatalf("Should get OffsetEarliest == 0 Got %#v instead ", offe)
+		}
+		offl, err := broker.OffsetLatest(name, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if offl != 1 {
+			t.Fatalf("Should get OffsetLatest == 1. Got %#v instead ", offl)
+		}
+
+	}
+
 }
 
 func TestCompression(t *testing.T) {


### PR DESCRIPTION
In the parser of OffsetResponse was an error which caused the wrong responses for kafka >= KafkaV1

Fixed it and added integration test for this case.