### PR TITLE
be explicit about types when encoding

### DIFF
--- a/proto/messages_test.go
+++ b/proto/messages_test.go
@@ -1565,6 +1565,7 @@ func BenchmarkProduceRequestMarshal(b *testing.B) {
 		},
 	}
 	b.ResetTimer()
+	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
 		if _, err := req.Bytes(); err != nil {
@@ -1594,6 +1595,7 @@ func BenchmarkProduceResponseUnmarshal(b *testing.B) {
 		b.Fatalf("cannot serialize response: %s", err)
 	}
 	b.ResetTimer()
+	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
 		if _, err := ReadVersionedProduceResp(bytes.NewBuffer(raw), resp.Version); err != nil {
@@ -1618,6 +1620,7 @@ func BenchmarkFetchRequestMarshal(b *testing.B) {
 		},
 	}
 	b.ResetTimer()
+	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
 		if _, err := req.Bytes(); err != nil {
@@ -1662,6 +1665,7 @@ func BenchmarkFetchResponseUnmarshal(b *testing.B) {
 		b.Fatalf("cannot serialize response: %s", err)
 	}
 	b.ResetTimer()
+	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
 		if _, err := ReadVersionedFetchResp(bytes.NewBuffer(raw), KafkaV0); err != nil {

--- a/proto/serialization.go
+++ b/proto/serialization.go
@@ -289,72 +289,15 @@ func NewEncoder(w io.Writer) *encoder {
 	return &encoder{w: w}
 }
 
-func (e *encoder) Encode(value interface{}) {
+func (e *encoder) EncodeDuration(val time.Duration) {
 	if e.err != nil {
 		return
 	}
-	var b []byte
 
-	switch val := value.(type) {
-	case int8:
-		_, e.err = e.w.Write([]byte{byte(val)})
-	case int16:
-		b = e.buf[:2]
-		binary.BigEndian.PutUint16(b, uint16(val))
-	case int32:
-		b = e.buf[:4]
-		binary.BigEndian.PutUint32(b, uint32(val))
-	case int64:
-		b = e.buf[:8]
-		binary.BigEndian.PutUint64(b, uint64(val))
-	case uint16:
-		b = e.buf[:2]
-		binary.BigEndian.PutUint16(b, val)
-	case uint32:
-		b = e.buf[:4]
-		binary.BigEndian.PutUint32(b, val)
-	case uint64:
-		b = e.buf[:8]
-		binary.BigEndian.PutUint64(b, val)
-	case string:
-		buf := e.buf[:2]
-		binary.BigEndian.PutUint16(buf, uint16(len(val)))
-		e.err = writeAll(e.w, buf)
-		if e.err == nil {
-			e.err = writeAll(e.w, []byte(val))
-		}
-	case []byte:
-		buf := e.buf[:4]
-
-		if val == nil {
-			no := int32(-1)
-			binary.BigEndian.PutUint32(buf, uint32(no))
-			e.err = writeAll(e.w, buf)
-			return
-		}
-
-		binary.BigEndian.PutUint32(buf, uint32(len(val)))
-		e.err = writeAll(e.w, buf)
-		if e.err == nil {
-			e.err = writeAll(e.w, val)
-		}
-	case []int32:
-		e.EncodeArrayLen(len(val))
-		for _, v := range val {
-			e.Encode(v)
-		}
-	case time.Duration:
-		intVal := uint32(val / time.Millisecond)
-		b = e.buf[:4]
-		binary.BigEndian.PutUint32(b, intVal)
-	default:
-		e.err = fmt.Errorf("cannot encode type %T", value)
-	}
-
-	if b != nil {
-		e.err = writeAll(e.w, b)
-		return
-	}
+	intVal := uint32(val / time.Millisecond)
+	b := e.buf[:4]
+	binary.BigEndian.PutUint32(b, intVal)
+	_, e.err = e.w.Write(b)
 }
 
 func (e *encoder) EncodeInt8(val int8) {
@@ -362,7 +305,9 @@ func (e *encoder) EncodeInt8(val int8) {
 		return
 	}
 
-	_, e.err = e.w.Write([]byte{byte(val)})
+	b := e.buf[:1]
+	b[0] = byte(val)
+	_, e.err = e.w.Write(b)
 }
 
 func (e *encoder) EncodeInt16(val int16) {
@@ -385,6 +330,17 @@ func (e *encoder) EncodeInt32(val int32) {
 	e.err = writeAll(e.w, b)
 }
 
+func (e *encoder) EncodeInt32s(val []int32) {
+	if e.err != nil {
+		return
+	}
+
+	e.EncodeArrayLen(len(val))
+	for _, v := range val {
+		e.EncodeInt32(v)
+	}
+}
+
 func (e *encoder) EncodeInt64(val int64) {
 	if e.err != nil {
 		return
@@ -393,6 +349,17 @@ func (e *encoder) EncodeInt64(val int64) {
 	b := e.buf[:8]
 	binary.BigEndian.PutUint64(b, uint64(val))
 	e.err = writeAll(e.w, b)
+}
+
+func (e *encoder) EncodeInt64s(val []int64) {
+	if e.err != nil {
+		return
+	}
+
+	e.EncodeArrayLen(len(val))
+	for _, v := range val {
+		e.EncodeInt64(v)
+	}
 }
 
 func (e *encoder) EncodeUint32(val uint32) {

--- a/proto/serialization_test.go
+++ b/proto/serialization_test.go
@@ -24,27 +24,21 @@ func getTestEncoder() *encoder {
 
 func TestEncoder(t *testing.T) {
 	e := getTestEncoder()
-	e.Encode(int8(keyint))
+	e.EncodeInt8(int8(keyint))
 	if !bytes.Equal(b.Bytes(), bint8) {
 		t.Fatalf("bytes are not the same % x != % x", b.Bytes(), bint8)
 	}
 
 	e = getTestEncoder()
-	e.Encode(int64(keyint))
+	e.EncodeInt64(int64(keyint))
 	if !bytes.Equal(b.Bytes(), bint64) {
 		t.Fatalf("bytes are not the same % x != % x", b.Bytes(), bint64)
 	}
 
 	e = getTestEncoder()
-	e.Encode(string(keystr))
+	e.EncodeString(string(keystr))
 	if !bytes.Equal(b.Bytes(), bstr) {
 		t.Fatalf("bytes are not the same % x != % x", b.Bytes(), bstr)
-	}
-
-	e = getTestEncoder()
-	e.Encode([]byte(keystr))
-	if !bytes.Equal(b.Bytes(), bbyte) {
-		t.Fatalf("bytes are not the same % x != % x", b.Bytes(), bbyte)
 	}
 }
 


### PR DESCRIPTION
- prevents allocation for constants
- potentially prevents allocation for struct members, but they were
  probably on the heap already anyway...
- saves type checking
- makes encoding mirror decoding

For the marshalling benchmarks, this saves well over 50% of the
allocations, though they weren't particularly high for the scope of a
single message to send over the wire.

```
BenchmarkProduceRequestMarshal-4    30000  45983 ns/op   158280 B/op    326 allocs/op
BenchmarkProduceRequestMarshal-4    30000  44914 ns/op   158040 B/op    122 allocs/op

BenchmarkFetchRequestMarshal-4    2000000    755 ns/op      416 B/op     16 allocs/op
BenchmarkFetchRequestMarshal-4    3000000    509 ns/op      304 B/op      3 allocs/op
```