### PR TITLE
re-use decoder within a record batch in a fetch response

### DIFF
--- a/proto/serialization.go
+++ b/proto/serialization.go
@@ -28,6 +28,10 @@ func NewDecoder(r io.Reader) *decoder {
 	}
 }
 
+func (d *decoder) SetReader(r io.Reader) {
+	d.r = r
+}
+
 func (d *decoder) DecodeInt8() int8 {
 	if d.err != nil {
 		return 0


### PR DESCRIPTION
Previously, we were allocating two decoders per batch, and an additional
one for each record, but it's pretty easy to reuse, and in fact, it's a
bit more correct, because we were throwing away a potential error which
we now preserve.

For a 2M response, with ~19k batches, each with one record, this saves
about 25% of the parsing time and reduces allocations by 2*19k.